### PR TITLE
(!!!) prefix build system commands with bonsai_, ex: make->bonsai_make

### DIFF
--- a/ports-staging/9base/pkgfile
+++ b/ports-staging/9base/pkgfile
@@ -1,6 +1,6 @@
 version=09e95a2d6f8dbafc6601147b2f5f150355813be6
 source=http://github.com/suckless-mirror/$name/archive/$version.tar.gz
 build() {
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }

--- a/ports-staging/bonsai/pkgfile
+++ b/ports-staging/bonsai/pkgfile
@@ -16,9 +16,9 @@ prebuild() {
 }
 # ------------------------------------ #
 build() {
-    make
-    make install
-    make PREFIX="$root" install
+    bonsai_make
+    bonsai_make install
+    bonsai_make PREFIX="$root" install
 }
 postbuild() {
     cd "$root"/bin

--- a/ports-staging/dbus/pkgfile
+++ b/ports-staging/dbus/pkgfile
@@ -3,12 +3,12 @@ version=1.13.12
 source=https://$name.freedesktop.org/releases/$name/$name-$version.tar.xz
 deps='expat pkgconf'
 build() {
-    configure --with-init-scripts=none \
-              --with-dbus-user=messagebus \
-              --with-system-pid-file=/var/run/$name/$name.pid \
-              --without-x \
-              --disable-x11-autolaunch \
-              --disable-apparmor
-    make
-    make install
+    bonsai_configure --with-init-scripts=none \
+        --with-dbus-user=messagebus \
+        --with-system-pid-file=/var/run/$name/$name.pid \
+        --without-x \
+        --disable-x11-autolaunch \
+        --disable-apparmor
+    bonsai_make
+    bonsai_make install
 }

--- a/ports-staging/gnu-bc/pkgfile
+++ b/ports-staging/gnu-bc/pkgfile
@@ -3,11 +3,11 @@ version=1.07.1
 source=http://ftpmirror.gnu.org/gnu/$name/$name-$version.tar.gz
 deps=readline
 build() {
-    configure --with-readline
+    bonsai_configure --with-readline
 
     # do not regen docs (would require texinfo as dep)
     touch doc/*.info doc/*.1 doc/Makefile
 
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }

--- a/ports-staging/htop/pkgfile
+++ b/ports-staging/htop/pkgfile
@@ -3,9 +3,9 @@ version=2.2.0
 source=https://hisham.hm/$name/releases/$version/$name-$version.tar.gz
 deps='netbsd-curses python'
 build() {
-    configure LIBS='-lncursesw -lterminfo'
-    make
-    make install
+    bonsai_configure LIBS='-lncursesw -lterminfo'
+    bonsai_make
+    bonsai_make install
 }
 postbuild() {
     rm -rf "$pkg"/include \

--- a/ports-staging/libpcre/pkgfile
+++ b/ports-staging/libpcre/pkgfile
@@ -2,8 +2,7 @@ info='Perl Compatible Regular Expressions library'
 version=8.43
 source=http://ftp.pcre.org/pub/pcre/pcre-$version.tar.gz
 build() {
-    configure --enable-utf8 \
-              --enable-unicode-properties
-    make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
-    make install
+    bonsai_configure --enable-utf8 --enable-unicode-properties
+    bonsai_make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
+    bonsai_make install
 }

--- a/ports-staging/nano/pkgfile
+++ b/ports-staging/nano/pkgfile
@@ -5,9 +5,9 @@ deps=netbsd-curses
 build() {
     # note: --enable-tiny removes many features
     #       a regular user of nano might want
-    configure LIBS='-lncursesw -lterminfo' \
-              --enable-utf8 \
-              --enable-tiny
-    make
-    make install
+    bonsai_configure LIBS='-lncursesw -lterminfo' \
+        --enable-utf8 \
+        --enable-tiny
+    bonsai_make
+    bonsai_make install
 }

--- a/ports-staging/ncurses/pkgfile
+++ b/ports-staging/ncurses/pkgfile
@@ -3,20 +3,20 @@ version=6.1
 source=http://invisible-island.net/datafiles/release/$name.tar.gz
 build() {
     CFLAGS="$CFLAGS -D_GNU_SOURCE" \
-    configure --without-shared \
-              --without-cxx-binding \
-              --with-normal \
-              --with-termlib \
-              --with-caps \
-              --enable-database \
-              --enable-widec \
-              --enable-termcap \
-              --enable-db-install \
-              --enable-pc-files \
-              --with-fallbacks=vt100 \
-              --with-default-terminfo-dir="$root"/share/terminfo
-    make CFLAGS="$CFLAGS -D_GNU_SOURCE"
-    make ticdir="$pkg"/share/terminfo pkgdir="$pkg"/share/pkg-config install
+    bonsai_configure --without-shared \
+        --without-cxx-binding \
+        --with-normal \
+        --with-termlib \
+        --with-caps \
+        --enable-database \
+        --enable-widec \
+        --enable-termcap \
+        --enable-db-install \
+        --enable-pc-files \
+        --with-fallbacks=vt100 \
+        --with-default-terminfo-dir="$root"/share/terminfo
+    bonsai_make CFLAGS="$CFLAGS -D_GNU_SOURCE"
+    bonsai_make ticdir="$pkg"/share/terminfo pkgdir="$pkg"/share/pkg-config install
 }
 postbuild() {
     echo 'export TERMINFO=/share/terminfo' >> "$root"/etc/profile

--- a/ports-staging/pkg-config/pkgfile
+++ b/ports-staging/pkg-config/pkgfile
@@ -2,7 +2,7 @@ info='tool for managing compiler/linker flags'
 version=0.29.2
 source=http://$name.freedesktop.org/releases/$name-$version.tar.gz 
 build() {
-    configure --with-internal-glib
-    make
-    make install
+    bonsai_configure --with-internal-glib
+    bonsai_make
+    bonsai_make install
 }

--- a/ports-staging/posix-bc/pkgfile
+++ b/ports-staging/posix-bc/pkgfile
@@ -7,8 +7,8 @@ build() {
     CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" \
     CPPFLAGS="$CPPFLAGS" PREFIX="$PREFIX" \
     ./configure.sh -G -H -N $M
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }
 postbuild() {
     cd "$pkg"/bin

--- a/ports/bash/README.md
+++ b/ports/bash/README.md
@@ -1,5 +1,0 @@
-regression:
-
-bash errors out if compiled under `libedit` with a cryptic "xmalloc 0 bytes"
-
-fix later... dash mksh and loksh all compile fine.

--- a/ports/bash/pkgfile
+++ b/ports/bash/pkgfile
@@ -3,7 +3,8 @@ version=5.0
 source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
 deps=libedit
 build() {
-    LIBS='-lreadline -lcurses' configure --without-bash-malloc
-    make
-    make install
+    LIBS='-lreadline -lcurses' \
+        bonsai_configure --without-bash-malloc
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/bzip2/pkgfile
+++ b/ports/bzip2/pkgfile
@@ -1,7 +1,7 @@
 info='bz2 compression/decompression utility'
 version=1.0.7
-source=https://sourceware.org/pub/$name/$name-$version.tar.gz
+source=http://sourceware.org/pub/$name/$name-$version.tar.gz
 build() {
-    make CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
-    make CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64" install
+    bonsai_make CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64"
+    bonsai_make CFLAGS="$CFLAGS -D_FILE_OFFSET_BITS=64" install
 }

--- a/ports/curl/pkgfile
+++ b/ports/curl/pkgfile
@@ -3,7 +3,7 @@ version=7.65.1
 source=http://curl.haxx.se/download/$name-$version.tar.xz
 deps='libressl zlib'
 build() {
-    configure --without-librtmp --without-cyassl \
+    bonsai_configure --without-librtmp --without-cyassl \
               --without-libpsl --without-winidn \
               --without-libidn2 --without-gnutls \
               --without-winssl --without-schannel \
@@ -19,6 +19,6 @@ build() {
               --with-ssl=$pkgs/libressl \
               --with-zlib=$pkgs/zlib \
               --with-ca-bundle=/etc/ssl/cert.pem
-    make curl_LDFLAGS=-all-static
-    make curl_LDFLAGS=-all-static install
+    bonsai_make curl_LDFLAGS=-all-static
+    bonsai_make curl_LDFLAGS=-all-static install
 }

--- a/ports/dash/pkgfile
+++ b/ports/dash/pkgfile
@@ -2,7 +2,8 @@ info='Debian Alquist shell (DASH)'
 version=0.5.10
 source=http://gondor.apana.org.au/~herbert/$name/files/$name-$version.tar.gz
 prebuild() {
-# dash mkbuiltins script depends on "nl"
+# dash mkbuiltins script depends on "nl", 
+# which is not included with musl-libc
 cat > nl.c << EOF
 #include <stdio.h>
 int main() {
@@ -10,15 +11,16 @@ int main() {
     while(fgets(b, sizeof b, stdin)) { printf("%zu %s", i, b); i++; }
 }
 EOF
-cc nl.c -o nl
+bonsai_cc nl.c -o nl
 export PATH="$PWD:$PATH"
 }
 build() {
-    CC="$CC $CFLAGS" configure
-    make
-    make install
+    CC="$CC $CFLAGS" \
+        bonsai_configure
+    bonsai_make
+    bonsai_make install
 }
 postbuild() {
-    cd "$pkg"/bin
-    ln -s dash sh
+    rm nl
+    ln -s dash "$pkg"/bin/sh
 }

--- a/ports/dropbear/pkgfile
+++ b/ports/dropbear/pkgfile
@@ -15,24 +15,23 @@ prebuild() {
         > ifndef_wrapper.sh
 }
 build() {
-    configure --enable-static \
-              --disable-lastlog \
-              --disable-pututline \
-              --disable-pututxline \
-              --disable-syslog \
-              --disable-utmp \
-              --disable-utmpx \
-              --disable-wtmp \
-              --disable-wtmpx
-    make SCPPROGRESS=1 MULTI=1 \
+    bonsai_configure --enable-static \
+        --disable-lastlog \
+        --disable-pututline \
+        --disable-pututxline \
+        --disable-syslog \
+        --disable-utmp \
+        --disable-utmpx \
+        --disable-wtmp \
+        --disable-wtmpx
+    bonsai_make SCPPROGRESS=1 MULTI=1 \
          PROGRAMS="dropbear scp dbclient dropbearkey dropbearconvert"
-    make SCPPROGRESS=1 MULTI=1 \
+    bonsai_make SCPPROGRESS=1 MULTI=1 \
          PROGRAMS="dropbear scp dbclient dropbearkey dropbearconvert" \
          install
 }
 postbuild() {
-    cd "$pkg"/bin
-    ln -sf dropbear sshd
-    ln -sf dbclient ssh
-    ln -sf dropbearkey ssh-keygen
+    ln -sf dropbear "$pkg"/bin/sshd
+    ln -sf dbclient "$pkg"/bin/ssh
+    ln -sf dropbearkey "$pkg"/bin/ssh-keygen
 }

--- a/ports/dvtm/pkgfile
+++ b/ports/dvtm/pkgfile
@@ -3,6 +3,6 @@ version=0.15
 source=https://github.com/martanne/$name/archive/v$version.tar.gz
 deps=netbsd-curses
 build() {
-    make LIBS='-lncursesw -lterminfo'
-    make install
+    bonsai_make LIBS='-lncursesw -lterminfo'
+    bonsai_make install
 }

--- a/ports/file/pkgfile
+++ b/ports/file/pkgfile
@@ -3,7 +3,7 @@ version=5.37
 source=ftp://ftp.astron.com/pub/$name/$name-$version.tar.gz
 deps=zlib
 build() {
-    configure --disable-libseccomp
-    make
-    make install
+    bonsai_configure --disable-libseccomp
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/flex/pkgfile
+++ b/ports/flex/pkgfile
@@ -2,11 +2,12 @@ info='Fast Lexical Analyzer Generator'
 version=2.6.4
 source=http://sourceforge.net/projects/$name/files/$name-2.6.0.tar.xz/download
 build() {
-    configure
-    CFLAGS="-D_GNU_SOURCE $CFLAGS" make
-    make install
+    bonsai_configure
+    CFLAGS="-D_GNU_SOURCE $CFLAGS" \
+        bonsai_make
+    bonsai_make install
 }
 postbuild() {
-    cd $root/bin
-    [ ! -e lex ] && ln -sf $name lex
+    [ ! -e "$root"/bin/lex ] && 
+        ln -sf $name "$root"/bin/lex
 }

--- a/ports/gdbm/pkgfile
+++ b/ports/gdbm/pkgfile
@@ -2,7 +2,7 @@ info='GNU db -- database routines that use extensible hashing'
 version=1.9.1
 source=http://mirrors.kernel.org/gnu/$name/$name-$version.tar.gz
 build() {
-    configure --enable-libgdbm-compat
-    make
-    make install
+    bonsai_configure --enable-libgdbm-compat
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/git/pkgfile
+++ b/ports/git/pkgfile
@@ -32,8 +32,8 @@ build() {
     #
     # for some Rich Felker humor on the change:
     # https://public-inbox.org/git/20161004150848.GA7949@brightrain.aerifal.cx
-    make CFLAGS="-Icompat/regex $CFLAGS" \
-         CPPFLAGS="-Icompat/regex $CPPFLAGS" install
+    bonsai_make CFLAGS="-Icompat/regex $CFLAGS" \
+                CPPFLAGS="-Icompat/regex $CPPFLAGS" install
 }
 postbuild() {
     rm -f "$pkg"/lib/perl5/core_perl/perllocal.pod

--- a/ports/gnu-cpio/pkgfile
+++ b/ports/gnu-cpio/pkgfile
@@ -2,7 +2,8 @@ info='GNU tool to read/write tar and other archives'
 version=2.12
 source=https://mirrors.kernel.org/gnu/cpio/cpio-$version.tar.gz
 build() {
-    CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" configure
-    make
-    make install
+    CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" 
+        bonsai_make configure
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/inetutils/pkgfile
+++ b/ports/inetutils/pkgfile
@@ -2,7 +2,7 @@ info='ifconfig suite of utilities'
 version=1.9.4
 source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.xz
 build() {
-    configure --localstatedir=/var \
+    bonsai_configure --localstatedir=/var \
                 --sysconfdir=/etc  \
                 --disable-servers  \
                 --disable-rsh      \
@@ -12,6 +12,6 @@ build() {
                 --disable-logger   \
                 --disable-talk     \
                 --disable-telnet
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/libedit/pkgfile
+++ b/ports/libedit/pkgfile
@@ -3,9 +3,10 @@ version=3.1
 source=https://thrysoee.dk/editline/$name-20190324-$version.tar.gz
 deps=netbsd-curses
 build() {
-    CFLAGS="$CFLAGS -D_BSD_SOURCE" configure --enable-widec
-    make
-    make install
+    CFLAGS="$CFLAGS -D_BSD_SOURCE" 
+        bonsai_configure --enable-widec
+    bonsai_make
+    bonsai_make install
 }
 postbuild() {
     # create symlinks to be a drop-in replacement for readline

--- a/ports/libnl-tiny/pkgfile
+++ b/ports/libnl-tiny/pkgfile
@@ -2,8 +2,8 @@ info='a tiny version of the libnl netlink library'
 version=4225e93bec5304abee3386213213718367e54a93
 source=http://github.com/sabotage-linux/$name/archive/$version.tar.gz
 build() {
-    make ALL_LIBS=libnl-tiny.a
-    make ALL_LIBS=libnl-tiny.a install
+    bonsai_make ALL_LIBS=libnl-tiny.a
+    bonsai_make ALL_LIBS=libnl-tiny.a install
 }
 postbuild() {
     cd "$pkgs"/$name/lib

--- a/ports/libressl/pkgfile
+++ b/ports/libressl/pkgfile
@@ -2,12 +2,12 @@ info='fork of OpenSSL, providing Secure Sockets Layer and cryptography utilities
 version=2.9.2
 source=http://ftp.openbsd.org/pub/OpenBSD/LibreSSL/$name-$version.tar.gz
 build() {
-    configure --disable-hardening --disable-windows-ssp
+    bonsai_configure --disable-hardening --disable-windows-ssp
 
     mv -f libtool libtool.tmp
     printf "%s\n%s\n" '#!/bin/sh' 'set -ex' >> libtool
     cat libtool.tmp >> libtool
 
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/loksh/pkgfile
+++ b/ports/loksh/pkgfile
@@ -3,6 +3,6 @@ version=6.5
 source=http://github.com/dimkr/$name/archive/$version.tar.gz
 deps=libedit
 build() {
-    make NCURSES_LDFLAGS='-lncursesw -ltinfo'
-    make install
+    bonsai_make NCURSES_LDFLAGS='-lncursesw -ltinfo'
+    bonsai_make install
 }

--- a/ports/make/pkgfile
+++ b/ports/make/pkgfile
@@ -2,7 +2,9 @@ info='GNU make build automation tool'
 version=4.2.1
 source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
 build() {
-    CFLAGS="-D_GNU_SOURCE $CFLAGS" configure
-    CFLAGS="-D_GNU_SOURCE $CFLAGS" make
-    make install
+    CFLAGS="-D_GNU_SOURCE $CFLAGS" 
+        bonsai_configure
+    CFLAGS="-D_GNU_SOURCE $CFLAGS" 
+        bonsai_make
+    bonsai_make install
 }

--- a/ports/netbsd-curses/pkgfile
+++ b/ports/netbsd-curses/pkgfile
@@ -2,13 +2,14 @@ info="minimal NetBSD curses library ported to Linux"
 version=0.3.1
 source=http://github.com/sabotage-linux/$name/archive/v$version.tar.gz
 build() {
-    make all-static
-    make install-static
+    bonsai_make all-static
+    bonsai_make install-static
 
-    make terminfo/terminfo.cdb
+    bonsai_make terminfo/terminfo.cdb
     install -Dm0655 terminfo/terminfo.cdb "$pkg"/share/terminfo.cdb
 
-    $mans && make install-manpages
+    $mans && 
+        bonsai_make install-manpages
 }
 postbuild() {
     # symlink '-ltinfo' for compatibility

--- a/ports/perl/pkgfile
+++ b/ports/perl/pkgfile
@@ -3,7 +3,7 @@ version=5.30.0
 source=http://www.cpan.org/src/5.0/$name-$version.tar.xz
 deps='zlib bzip2'
 prebuild() {
-    patch
+    bonsai_patch
 
     # musl does not have a separate libnsl
     # remove it as a dep from the configure script
@@ -53,8 +53,8 @@ build() {
         -Uusedl
 
     CPATH="$root/include" C_INCLUDE_PATH="$CPATH" \
-    make
-    make install
+        bonsai_make
+    bonsai_make install
 }
 postbuild() {
     msg 'cleaning up'

--- a/ports/pkgconf/pkgfile
+++ b/ports/pkgconf/pkgfile
@@ -8,9 +8,9 @@ build() {
    # --with-system-includedir="$root/include:/include" \
    # --with-pkg-config-dir="$root/lib/pkgconfig:/lib/pkgconfig"
    
-    configure
-    make
-    make install
+    bonsai_configure
+    bonsai_make
+    bonsai_make install
 }
 postbuild() {
     cd "$pkgs"/$name/bin

--- a/ports/sbase/pkgfile
+++ b/ports/sbase/pkgfile
@@ -2,6 +2,6 @@ info="suckless base"
 version=036449cdf13b5fd9364f7b9cc910fce7923ee4bf
 source=http://github.com/suckless-mirror/$name/archive/$version.tar.gz
 build() {
-    make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box
-    make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box-install
+    bonsai_make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box
+    bonsai_make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box-install
 }

--- a/ports/tree/pkgfile
+++ b/ports/tree/pkgfile
@@ -2,6 +2,6 @@ info='display trees of directories'
 version=1.8.0
 source=http://mama.indstate.edu/users/ice/$name/src/$name-$version.tgz
 build() {
-    make USER_CFLAGS="$CFLAGS"
-    make USER_CFLAGS="$CFLAGS" install
+    bonsai_make USER_CFLAGS="$CFLAGS"
+    bonsai_make USER_CFLAGS="$CFLAGS" install
 }

--- a/ports/ubase/pkgfile
+++ b/ports/ubase/pkgfile
@@ -2,6 +2,6 @@ info="suckless unportable base"
 version=3c88778c6c85d97fb63c41c05304519e0484b07c
 source=http://github.com/suckless-mirror/$name/archive/$version.tar.gz
 build() {
-    make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box
-    make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box-install
+    bonsai_make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box
+    bonsai_make CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS" $name-box-install
 }

--- a/ports/vim/pkgfile
+++ b/ports/vim/pkgfile
@@ -3,10 +3,10 @@ version=8.1.1685
 source=http://github.com/$name/$name/archive/v$version.tar.gz
 deps='netbsd-curses acl'
 build() {
-    configure LIBS='-lncursesw -ltinfow' \
-                --disable-gui \
-                --without-x \
-                --disable-gpm
-    make
-    make install
+    bonsai_configure LIBS='-lncursesw -ltinfow' \
+        --disable-gui \
+        --without-x \
+        --disable-gpm
+    bonsai_make
+    bonsai_make install
 }

--- a/ports/wpa_supplicant/pkgfile
+++ b/ports/wpa_supplicant/pkgfile
@@ -3,7 +3,7 @@ version=2.5
 source=http://w1.fi/releases/$name-$version.tar.gz
 deps="libressl libnl-tiny zlib"
 prebuild() {
-patch
+bonsai_patch
 cd wpa_supplicant
 
 cp -f defconfig .config
@@ -25,7 +25,7 @@ sed 's|CONFIG_DRIVER_WEXT=y|#CONFIG_DRIVER_WEXT=y|' .config > .config.tmp
 mv -f .config.tmp .config
 }
 
-build() { make ; }
+build() { bonsai_make ; }
 
 postbuild() {
     # wpa_supplicant's "make install" sucks.

--- a/ports/xz-embedded/pkgfile
+++ b/ports/xz-embedded/pkgfile
@@ -3,7 +3,7 @@ version=20130513
 source=https://tukaani.org/xz/$name-$version.tar.gz
 build() {
     cd userspace
-    make
+    bonsai_make
     install -Dm0755 xzminidec "$pkg"/bin/xzminidec
 }
 postbuild() {

--- a/src/build
+++ b/src/build
@@ -11,7 +11,7 @@ run_build() {
         prebuild || die "$1 prebuild() failed"
     # else, try to apply any patches (convenience)
     elif ! ismetapkg $name ; then
-        patch || die "$1 generic prebuild() failed"
+        bonsai_patch || die "$1 generic prebuild() failed"
     fi
 
     # run user defined build(), if exists
@@ -32,8 +32,8 @@ run_build() {
 }
 
 # convenience functions
-cc()  { $cc  -static -Os -s "$@" ; }
-gcc() { $gcc -static -Os -s "$@" ; }
+bonsai_cc()  { $cc  -static -Os -s "$@" ; }
+bonsai_gcc() { $gcc -static -Os -s "$@" ; }
 
 getflags() {
 #    causing issues, for now remove
@@ -63,16 +63,16 @@ getflags() {
 
 # convenience function, tries to find all *.patch
 # in $work/$name directory and apply them
-patch() {
+bonsai_patch() {
     find . ! -name . -prune -name "*.patch" | while read -r patch ; do
-        command patch -p0 < "$patch" | msg
+        patch -p0 < "$patch" | msg
     done
     unset patch
 }
 
-autogen() { configure --autogen ; }
+bonsai_autogen() { configure --autogen ; }
 
-configure() {
+bonsai_configure() {
     if [ "$1" = "--autogen" ] ; then
         FILE=autogen.sh
         shift
@@ -130,11 +130,11 @@ configure() {
     return $1
 }
 
-make() {
+bonsai_make() {
     $mans   || _mans='MANDIR=/dev/null'
     $quiet  && _quiet='-s'
 
-    command make $makeflags -j${jobs:=1} $_mans $_quiet \
+    make $makeflags -j${jobs:=1} $_mans $_quiet \
         CC="$CC" \
         cc="$CC" \
         DESTDIR="$DESTDIR" \
@@ -155,13 +155,13 @@ make() {
 # run if pkgfile doesn't define a custom build()
 generic_build() {
     if [ -s configure ] ; then
-        configure
+        bonsai_configure
     elif [ -s autogen.sh ] ; then
-        autogen
-        configure
+        bonsai_autogen
+        bonsai_configure
     fi
-    make
-    make install
+    bonsai_make
+    bonsai_make install
 }
 
 # remove junk files from $pkgs/$1


### PR DESCRIPTION
Huge syntax breaking change.

The need for this came from someone who's `/bin/sh` pointed to `bash`. Bash, when called from a symlink named `/bin/sh` this way defaults to `set -o posix` mode.

Turns out, our build system wasn't entirely posix. We were using `make() { ; }` for example as a convenience "alias" function. This was not getting called by the bash-sh, instead was `/usr/bin/make`.

This now fixes this problem, and frankly, makes the codebase better. It should *never* have been the previous way.

To write pkgfiles under the new syntax, see this example:

```bash
info="GNU Bourne Again Shell"
version=5.0
source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
deps=libedit
build() {
    LIBS='-lreadline -lcurses' \
        bonsai_configure --without-bash-malloc
    bonsai_make
    bonsai_make install
}
```