### PR TITLE
fix variable $name not found

### DIFF
--- a/src/ports
+++ b/src/ports
@@ -55,6 +55,7 @@ portinfo() {
     [ $# -gt 1 ] && die "info(): too many arguments"
     [ $# -eq 0 ] && die "info(): no argument provided"
     pkgname=$1
+	name=$1
     pkgfile="$ports"/$pkgname/pkgfile
 
     [ -f "$pkgfile" ] || die "addpkg(): could not source $pkgname's pkgfile"


### PR DESCRIPTION
# Situation:
    bonsai info git
# Expected behavior:
```
name:    git
info:    git version control system
version: 2.22.0
source:  http://mirrors.edge.kernel.org/pub/software/scm/git/git-2.22.0.tar.xz
depends: none
```
# Actual behavior:
```
name:    git
info:    git version control system
version: 2.22.0
source:  http://mirrors.edge.kernel.org/pub/software/scm//-2.22.0.tar.xz
depends: none
```
this is because in git's pkgfile, $name is used instead of git in source, but in this context, only pkgname is defined, not name. This is only a workaround, I think it would be appropriate to choose $pkgname OR $name and use it everywhere.