### PR TITLE
addpkg: more standard y/n prompt

### DIFF
--- a/src/addpkg
+++ b/src/addpkg
@@ -38,7 +38,7 @@ addpkg() {
         # note: $dep_needed is padded by spaces
         printf "\n  %s\n\n" "$1"
         if [ -z "$NO_PROMPT" ] ; then
-            msg_no_nl "continue? (y/n): "
+            msg_no_nl "continue? [Y/n]: "
             read -r ans
             case "$ans" in
                 y|"") ;; # "" is equivalent to user pressing enter


### PR DESCRIPTION
At least **apt** and **xbps** have this kind of y/n prompt. Also it is clear on the first look that Y is default.