### PR TITLE
New package groff

### DIFF
--- a/ports/groff/pkgfile
+++ b/ports/groff/pkgfile
@@ -1,10 +1,16 @@
 info='GNU version of troff typesetting system'
-source='http://ftp.gnu.org/gnu/groff/groff-1.22.4.tar.gz'
-sha256='e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293'
-deps='texinfo'
+version=1.22.4
+source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
+sha256=e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293
+deps=texinfo
 build() {
-    CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
-    bonsai_configure --without-x
+    CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" \
+    bonsai_configure --without-x --with-doc=no
     bonsai_make
     bonsai_make install
+}
+postbuild() {
+    ln -sf eqn "$pkg"/bin/geqn
+    ln -sf tbl "$pkg"/bin/gtbl
+    ln -sf soelim "$pkg"/bin/zsoelim
 }

--- a/ports/groff/pkgfile
+++ b/ports/groff/pkgfile
@@ -1,0 +1,10 @@
+info='GNU version of troff typesetting system'
+source='http://ftp.gnu.org/gnu/groff/groff-1.22.4.tar.gz'
+sha256='e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293'
+deps='texinfo'
+build() {
+    CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
+    bonsai_configure --without-x
+    bonsai_make
+    bonsai_make install
+}

--- a/ports/texinfo/pkgfile
+++ b/ports/texinfo/pkgfile
@@ -1,5 +1,5 @@
-info='The GNU Documentation System'
+info='The GNU documentation system'
 version=6.6
-source="http://ftp.gnu.org/gnu/$name/$name-$version.tar.xz"
+source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.xz
+deps=perl
 sha256=9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66
-deps='perl'

--- a/ports/texinfo/pkgfile
+++ b/ports/texinfo/pkgfile
@@ -1,0 +1,5 @@
+info='The GNU Documentation System'
+version=6.6
+source="http://ftp.gnu.org/gnu/$name/$name-$version.tar.xz"
+sha256=9bb9ca00da53f26a7e5725eee49689cd4a1e18d25d5b061ac8b2053018d93d66
+deps='perl'


### PR DESCRIPTION
Should I use perl in deps of groff when groff requires texinfo that requires perl? But groff requires perl too.