### PR TITLE
ports: add missing dependency to groff

### DIFF
--- a/ports/groff/pkgfile
+++ b/ports/groff/pkgfile
@@ -2,6 +2,8 @@ info='GNU version of troff typesetting system'
 version=1.22.4
 source=http://ftp.gnu.org/gnu/$name/$name-$version.tar.gz
 sha256=e78e7b4cb7dec310849004fa88847c44701e8d133b5d4c13057d876c1bad0293
+deps=perl
+
 build() {
     CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE" \
     bonsai_configure --without-x --with-doc=no


### PR DESCRIPTION
Perl is a build time dependency. It was a dependency of texinfo, but texinfo isn't anymore a dependency for groff.
#31